### PR TITLE
Fix see message from global from support

### DIFF
--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -56,21 +56,38 @@ trait InteractsWithMail
         return $this;
     }
 
-    public function seeMessageFrom($email)
+    public function seeMessageFrom($email, $name = NULL)
     {
         $this->seeMessage();
 
-        $from = $this->lastMessage()->from->first();
+        $this->lastMessage()->from->each(function ($nameOrEmail, $emailOrIndex) use ($email, $name) {
+            $fromEmail = is_int($emailOrIndex) ? $nameOrEmail : $emailOrIndex;
+            $fromName = is_int($emailOrIndex) ? null : $nameOrEmail;
 
-        $this->assertEquals(
-            $email,
-            $from,
-            sprintf(
-                'Expected to find message from "[%s]", but found "[%s]".',
+            $this->assertEquals(
                 $email,
-                $from
-            )
-        );
+                $fromEmail,
+                sprintf(
+                    'Expected to find message from "[%s]", but found "[%s]".',
+                    $email,
+                    $fromEmail
+                )
+            );
+
+            if (! $name) {
+                return;
+            }
+
+            $this->assertEquals(
+                $name,
+                $fromName,
+                sprintf(
+                    'Expected to find message from "[%s]", but found "[%s]".',
+                    $name,
+                    $fromName
+                )
+            );
+        });
 
         return $this;
     }

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -61,6 +61,8 @@ trait InteractsWithMail
         $this->seeMessage();
 
         $this->lastMessage()->from->each(function ($nameOrEmail, $emailOrIndex) use ($email, $name) {
+            // If no name is specified, the structure is ['hello@example.org'], if specified, it's
+            // ['hello@example.org' => 'From Example']
             $fromEmail = is_int($emailOrIndex) ? $nameOrEmail : $emailOrIndex;
             $fromName = is_int($emailOrIndex) ? null : $nameOrEmail;
 

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -76,4 +76,17 @@ class InteractsWithMailTest extends TestCase
         $this->seeHeaders('X-MailThief-Variables');
         $this->seeHeaders('X-MailThief-Variables', json_encode(['mailthief_id' => 2]));
     }
+
+    public function test_global_from()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        $mailer->alwaysFrom(['me@example.com' => 'Example Person']);
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $this->seeMessageFrom('me@example.com');
+    }
 }

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -81,12 +81,13 @@ class InteractsWithMailTest extends TestCase
     {
         $mailer = $this->mailer = $this->getMailThief();
 
-        $mailer->alwaysFrom(['me@example.com' => 'Example Person']);
+        $mailer->alwaysFrom('me@example.com', 'Example Person');
 
         $mailer->send('example-view', [], function ($m) {
             $m->to('john@example.com');
         });
 
         $this->seeMessageFrom('me@example.com');
+        $this->seeMessageFrom('me@example.com', 'Example Person');
     }
 }


### PR DESCRIPTION
With the addition of being able to set `alwaysFrom` in MailThief, `seeMessageFrom` was broken because we store global from information as an associative array. `seeMessageFrom` wasn't aware of this and if the name was set, was comparing the name to the passed in email address.

Resolves #51