### PR TITLE
Improvements for PHPUnit and PHP version tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,13 @@
 name: tests
 
-on:
-  pull_request:
+on: [pull_request]
 
 jobs:
   tests:
     strategy:
       matrix:
         os: [macOS, Ubuntu, Windows]
-        php: [7.0, 7.1, 7.2]
+        php: [7.0, 7.1, 7.2, 7.3, 7.4]
 
         include:
           - os: macOS

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/view": "5.*"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.3",
         "laravel/framework": ">=5.0 <5.5",
         "phpunit/phpunit": "^5.5"
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\View\Factory;
 use MailThief\MailThiefFiveFourCompatible;
 
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected function getViewFactory()
     {


### PR DESCRIPTION
# Changed log

- Add `php-7.3` and `php-7.4` version tests during GitHub Actions.
- It should be good to use the `\PHPUnit\Framework\TestCase` to easy to migrate stable `PHPUnit` versions easily.